### PR TITLE
Fix Typos and Update Default Gauge List

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add any new token assets to `/src/assets/tokens` and new protocol assets to `src
 - You should use an SVG file.
 - If you absolutely do not have an SVG file add a png to `src/assets/tokens/new` or `src/assets/protocols/new`. Ensure it is larger than 128x128 and is very high quality.
 
-### 2. Update JSON files
+### 3. Update JSON files
 
 1. Navigate to `src/gauges/{network}/defaultGaugeList.json` where `{network}` is the network you're adding to (e.g., "bartio" for the Bartio testnet).
 

--- a/src/gauges/bartio/defaultGaugeList.json
+++ b/src/gauges/bartio/defaultGaugeList.json
@@ -275,19 +275,19 @@
   ],
   "types": {
     "amm": {
-      "description": "Token that where minted to provide liquidity to AMM pools",
+      "description": "Token that were minted to provide liquidity to AMM pools",
       "name": "Automated Market Maker"
     },
     "cdp": {
-      "description": "Tokens that where minted to open a collateral debt position",
+      "description": "Tokens that were minted to open a collateral debt position",
       "name": "Collateral Debt Position"
     },
     "perps": {
-      "description": "Tokens that where minted to provide liquidity to a perpetual futures dex",
+      "description": "Tokens that were minted to provide liquidity to a perpetual futures dex",
       "name": "Perpetuals"
     },
     "vault": {
-      "description": "Tokens that where minted to provide liquidity to vault with a yield farming strategy",
+      "description": "Tokens that were minted to provide liquidity to vault with a yield farming strategy",
       "name": "Vault Token"
     }
   },


### PR DESCRIPTION
	1.	Corrected grammatical typos in src/gauges/bartio/defaultGaugeList.json:
	•	Updated “where” to “were” in descriptions for token types (amm, cdp, perps, and vault).
	2.	Minor adjustments to the README.md:
	•	Clarified instructions in the JSON file update process.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated README.md section headers and reordered steps for adding assets.

- **Bug Fixes**
	- Corrected grammatical errors in gauge descriptions for AMM, CDP, Perps, and Vault token types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->