### PR TITLE
fix: singular underlying lp token

### DIFF
--- a/scripts/_/validate-gauge-names.ts
+++ b/scripts/_/validate-gauge-names.ts
@@ -31,10 +31,23 @@ export const validateGaugeNames = async ({
         })
       }),
     )
-    const name = symbols.join('-')
+    const underlyingTokenSymbols = symbols.join('-')
 
-    if (gauge.name !== name) {
-      errors.push(`${gauge.name} does not match ${name}.`)
+    if (gauge.name !== underlyingTokenSymbols) {
+      rpcLookupCount += 1
+      if (rpcLookupCount % RPC_REQUESTS_PER_SECOND === 0) {
+        await delay(ONE_SECOND)
+      }
+      const lpTokenSymbol = await getTokenSymbol({
+        errors,
+        token: gauge.lpTokenAddress as Address,
+      })
+
+      if (gauge.name !== lpTokenSymbol) {
+        errors.push(
+          `${gauge.name} does not match ${lpTokenSymbol} or ${underlyingTokenSymbols}.`,
+        )
+      }
     }
   }
 }

--- a/src/gauges/bartio.json
+++ b/src/gauges/bartio.json
@@ -16,7 +16,7 @@
       "beraRewardsVault": "0xC5Cb3459723B828B3974f7E58899249C2be3B33d",
       "lpTokenAddress": "0x1306D3c36eC7E38dd2c128fBe3097C2C2449af64",
       "mintUrl": "https://bartio.berps.berachain.com/vault",
-      "name": "HONEY",
+      "name": "bHONEY",
       "protocol": "berps",
       "types": ["perps"],
       "underlyingTokens": ["0x0E4aaF1351de4c0264C5c7056Ef3777b41BD8e03"]
@@ -121,7 +121,7 @@
       "beraRewardsVault": "0x72e222116fC6063f4eE5cA90A6C59916AAD8352a",
       "lpTokenAddress": "0x3a7f6f2F27f7794a7820a32313F4a68e36580864",
       "mintUrl": "https://magic.beraborrow.com/pool/deposit",
-      "name": "NECT",
+      "name": "sNECT",
       "protocol": "beraborrow",
       "types": ["cdp"],
       "underlyingTokens": ["0xf5AFCF50006944d17226978e594D4D25f4f92B40"]
@@ -142,7 +142,7 @@
       "beraRewardsVault": "0x6582414E830d91C8016C10ceD72157106F908145",
       "lpTokenAddress": "0xdCeBAf53b18986bdE2aEb400a9acC3341Bb6ce3A",
       "mintUrl": "https://betabersion.junkyursas.com/vault",
-      "name": "JNKY",
+      "name": "juJNKY",
       "protocol": "junkyursas",
       "types": ["vault"],
       "underlyingTokens": ["0xa0525273423537BC76825B4389F3bAeC1968f83F"]
@@ -150,8 +150,8 @@
     {
       "beraRewardsVault": "0x3E1FfDD1AD1e4774693CBCCdF9C737De8713D984",
       "lpTokenAddress": "0x12Afd7A3324B689e32eEa71902DCbA5ED72Ee67E",
-      "mintUrl": "https://testnet.zeru.finance/v1/Assets?asset=0x0e4aaf1351de4c0264c5c7056ef3777b41bd8e03",
-      "name": "HONEY",
+      "mintUrl": "https://legacy.zeru.finance/v1/Assets?asset=0x0e4aaf1351de4c0264c5c7056ef3777b41bd8e03",
+      "name": "zberaHONEY",
       "protocol": "zeru",
       "types": ["vault"],
       "underlyingTokens": ["0x0E4aaF1351de4c0264C5c7056Ef3777b41BD8e03"]

--- a/src/tokens/bartio.json
+++ b/src/tokens/bartio.json
@@ -43,6 +43,13 @@
       "tags": ["stablecoin", "featured"]
     },
     {
+      "address": "0x1306D3c36eC7E38dd2c128fBe3097C2C2449af64",
+      "decimals": 18,
+      "image": "bhoney.svg",
+      "symbol": "bHONEY",
+      "tags": ["stablecoin"]
+    },
+    {
       "address": "0xd6D83aF58a19Cd14eF3CF6fe848C9A4d21e5727c",
       "decimals": 6,
       "image": "usdc.svg",


### PR DESCRIPTION
@multibear-infra So singular underlying tokens work differently in that the image used is often a different image and the name is different. So we're going to have to figure out some universal truths here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced gauge name validation process with additional comparison checks.
	- Added new token entry for "bHONEY".

- **Bug Fixes**
	- Updated gauge names for various tokens, including changes to HONEY, NECT, and JNKY.
	- Updated mint URL for a gauge entry.

- **Documentation**
	- Improved error reporting for gauge name validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->