### PR TITLE
fix: make mintUrl optional

### DIFF
--- a/schema/gauge-list-schema.json
+++ b/schema/gauge-list-schema.json
@@ -27,7 +27,6 @@
         "required": [
           "beraRewardsVault",
           "lpTokenAddress",
-          "mintUrl",
           "name",
           "protocol",
           "types",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Schema Update**
	- Modified validation rules for gauge list schema
	- Removed `mintUrl` as a required property for gauge entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->