### PR TITLE
fix bera reward vaults instead of infrared vaults

### DIFF
--- a/src/gauges/mainnet.json
+++ b/src/gauges/mainnet.json
@@ -64,7 +64,7 @@
       "underlyingTokens": ["0xFCBD14DC51f0A4d49d5E53C2E0950e0bC26d0Dce"]
     },
     {
-      "beraRewardsVault": "0xeFFD92E7435Dc32995b5b4BFf32b6451d685Fc2e",
+      "beraRewardsVault": "0x9c3110123c515CAF1866B28C031dFeb5ed8EbF0C",
       "lpTokenAddress": "0xF2d2d55Daf93b0660297eaA10969eBe90ead5CE8",
       "name": "USD₮0",
       "protocol": "dolomite",
@@ -72,7 +72,7 @@
       "underlyingTokens": ["0x779Ded0c9e1022225f8E0630b35a9b54bE713736"]
     },
     {
-      "beraRewardsVault": "0xd134a653E00f752b59597BFBc18AA0583232f109",
+      "beraRewardsVault": "0xdb2f42BEDC87586C6E4b510CFC4675d6D86Ff886",
       "lpTokenAddress": "0xf7b5127B510E568fdC39e6Bb54e2081BFaD489AF",
       "name": "WETH",
       "protocol": "dolomite",
@@ -80,7 +80,7 @@
       "underlyingTokens": ["0x2F6F07CDcf3588944Bf4C42aC74ff24bF56e7590"]
     },
     {
-      "beraRewardsVault": "0xC43aA390773914CEcA3f35a0c013c5B89Ca73ca0",
+      "beraRewardsVault": "0x7D960f4D9534aCb6f0fc963CC807b21655f35C76",
       "lpTokenAddress": "0x29cF6e8eCeFb8d3c9dd2b727C1b7d1df1a754F6f",
       "name": "WBTC",
       "protocol": "dolomite",


### PR DESCRIPTION
Fixing 3 dolomite vaults which had infrared vault address where bera reward vault address was supposed to go
