### PR TITLE
ci: use built-in GITHUB_TOKEN for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,13 +9,17 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v4
+        uses: cycjimmy/semantic-release-action@v6
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
The `Release` workflow has been failing since April on two expired credentials:

```
✘  EINVALIDNPMTOKEN Invalid npm token.
✘  EINVALIDGHTOKEN  Invalid GitHub token.
```

`secrets.RELEASE_TOKEN` is a personal access token last set 2025-05-26 that has since lapsed. This drops it in favour of the `GITHUB_TOKEN` GitHub mints for every run: semantic-release only creates a tag and a GitHub release here — no `@semantic-release/git`, nothing pushes to `main` — so the run-scoped token is sufficient, never expires, and one long-lived credential leaves the repo.

The explicit `permissions:` block is what grants that token the access semantic-release needs. No workflow in this repo triggers on tags or releases, so the usual caveat that `GITHUB_TOKEN` releases do not fire downstream workflows does not apply.

Also bumps `actions/checkout@v4`→`v7` and `cycjimmy/semantic-release-action@v4`→`v6`, clearing the Node 20 deprecation warnings.

Note: `secrets.NPM_TOKEN` is expired as well and must be rotated separately — merging this alone leaves the release red on the npm half.